### PR TITLE
feat: Copy tweet embed html to clipbaord

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": 3,
   "name": "Copy Tweet Embed",
   "action": {
-    "default_title": "Copy URL"
+    "default_title": "Copy Tweet Embed"
   },
-  "version": "0.0.0",
+  "version": "0.0.1",
   "permissions": ["activeTab", "scripting", "clipboardWrite"],
   "host_permissions": ["https://publish.twitter.com/*"],
   "background": {

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   },
   "version": "0.0.0",
   "permissions": ["activeTab", "scripting", "clipboardWrite"],
+  "host_permissions": ["https://publish.twitter.com/*"],
   "background": {
     "service_worker": "src/background.ts",
     "type": "module"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copy-tweet-embed",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copy-tweet-embed",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0-beta.33",
         "@types/chrome": "^0.0.323",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copy-tweet-embed",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/background.ts
+++ b/src/background.ts
@@ -17,7 +17,7 @@ chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
     target: { tabId },
     func: () => {
       chrome.runtime.onMessage.addListener((msg, _, _sendResponse) => {
-        if (msg.type === "copyToClipboard") {
+        if (msg.type === "copyTweetEmbedToClipboard") {
           navigator.clipboard.writeText(msg.html);
         }
       });
@@ -25,7 +25,7 @@ chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
   });
 
   chrome.tabs.sendMessage(tabId, {
-    type: "copyToClipboard",
+    type: "copyTweetEmbedToClipboard",
     html: oembed.html,
   });
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,19 +1,31 @@
-chrome.action.onClicked.addListener((tab: chrome.tabs.Tab) => {
-  const tabId: number | undefined = tab.id;
+const OEMBED_API_URL = "https://publish.twitter.com/oembed";
+
+chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
+  const url = tab.url;
+  if (!url) return;
+  if (!url.match(/^https:\/\/x\.com\/.+\/status\/\d+/)) return;
+
+  const oembed = await fetch(
+    `${OEMBED_API_URL}?url=${encodeURIComponent(url)}`,
+  ).then((r) => r.json());
+  if (!oembed.html) return;
+
+  const tabId = tab.id;
   if (!tabId) return;
 
-  chrome.scripting
-    .executeScript({
-      target: { tabId },
-      func: () => {
-        // Write the current page's URL to the clipboard
-        navigator.clipboard
-          .writeText(window.location.href)
-          .then(() => alert(`URL copied: ${window.location.href}`))
-          .catch((err: Error) => alert(`Failed to copy URL: ${err.message}`));
-      },
-    })
-    .catch((err: Error) => {
-      console.error("Script injection failed:", err);
-    });
+  await chrome.scripting.executeScript({
+    target: { tabId },
+    func: () => {
+      chrome.runtime.onMessage.addListener((msg, _, _sendResponse) => {
+        if (msg.type === "copyToClipboard") {
+          navigator.clipboard.writeText(msg.html);
+        }
+      });
+    },
+  });
+
+  chrome.tabs.sendMessage(tabId, {
+    type: "copyToClipboard",
+    html: oembed.html,
+  });
 });


### PR DESCRIPTION
This pull request introduces a new feature to copy tweet embeds instead of just URLs. It updates the extension's metadata, enhances the background script to fetch and copy tweet embed HTML, and adjusts permissions to support the new functionality.

### Metadata Updates:
* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L5-R9): Updated the extension name and default title to reflect the new functionality, incremented the version to `0.0.1`, and added `host_permissions` for accessing the Twitter oEmbed API.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version to `0.0.1` to align with the manifest changes.

### Background Script Enhancements:
* [`src/background.ts`](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fL1-R29): Replaced the functionality to copy the current page's URL with a new implementation that fetches the tweet embed HTML from Twitter's oEmbed API and copies it to the clipboard. Added URL validation for Twitter status pages and introduced a listener for handling clipboard operations.